### PR TITLE
putgitrepo typo in larbs.sh fix

### DIFF
--- a/larbs.sh
+++ b/larbs.sh
@@ -142,7 +142,7 @@ putgitrepo() { # Downloads a gitrepo $1 and places the files in $2 only overwrit
 	dir=$(mktemp -d)
 	[ ! -d "$2" ] && mkdir -p "$2" && chown -R "$name:wheel" "$2"
 	chown -R "$name:wheel" "$dir"
-	sudo -u "$name" git clone -b "$branch" --depth 1 "$1" "$dir/gitrepo" >/dev/null 2>&1 &&
+	sudo -u "$name" git clone -b "$branch" --depth 1 "$1" "$dir/gitrepo" >/dev/null 2>&1
 	sudo -u "$name" cp -rfT "$dir/gitrepo" "$2"
 	}
 


### PR DESCRIPTION
Config files didn't copy to home folder. I tried using larbs.sh a couple times in a vm and after it finished with no errors xorg woudn't start. I checked the `~/.local` folder and it only had  `src` in it (no `bin `or `share`). Removing` &&` in putgitrepo function worked for me. Im new to shell scripting and it's my first pull request but i hope it works.